### PR TITLE
Added two failing date query tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function toMongo(value, query) {
 	var operators = parse.operators,
 		operator;
 
-	if (value && typeof value === 'object' && !(value instanceof RegExp)) {
+	if (value && typeof value === 'object' && !(value instanceof RegExp) && !(value instanceof Date)) {
 		if (Array.isArray(value)) {
 			return value.map(function (v) {
 				return toMongo(v);
@@ -154,7 +154,7 @@ function and(a, b) {
 			}
 		}
 
-		if (source && typeof source === 'object' && !(source instanceof RegExp)) {
+		if (source && typeof source === 'object' && !(source instanceof RegExp) && !(source instanceof Date)) {
 			if (Array.isArray(source)) {
 				// shallow copy arrays
 				source = (dest || []).concat(source);

--- a/tests/index.js
+++ b/tests/index.js
@@ -335,6 +335,29 @@ define(function (require) {
 			expected.limit = 10;
 
 			assert.deepEqual(actual, expected);
-		}
+		},
+
+        'can query a date': function() {
+            var query = new Query().lt('created', new Date(2015, 6, 10)),
+                actual = mongoRql(query);
+
+            expected.criteria = {
+                'created': { $lt: new Date(2015, 6, 10) }
+            };
+
+            assert.deepEqual(actual, expected);
+        },
+
+        'can parse a string query with a date': function () {
+            var dateQuery = 'created=lt=date:2015-06-10T00:00:00Z',
+                query = new Query(dateQuery),
+                actual = mongoRql(query);
+
+            expected.criteria = {
+                'created': { $lt: new Date(2015, 6, 10) }
+            };
+
+            assert.deepEqual(actual, expected);
+        }
 	});
 });


### PR DESCRIPTION
Date queries are not working in mongo-rql.

I can get the tests "closer" to passing by implementing the following two changes, but then I quickly get into code I'm not currently understanding...
1. Implement the fixes from https://github.com/kriszyp/rql/commit/3e166a2f7c9fb67f03033ce00a05350bcd079948.  It's simply two line changes in a single file that enable correct parsing of date strings
2. Substitute line 25 of index.js with `if (value && typeof value === 'object' && !(value instanceof RegExp) && !(value instanceof Date)) {`.  This appears to fix the `Error: unsupported operator: undefined` error.  

After this, I hit a dead end.  A map reduce takes what appears to be a valid criteria and completely strips it out, and I can't figure out what the reduce is supposed to be doing.
